### PR TITLE
Format DateTime messages within tests for repeatability

### DIFF
--- a/Sage_Aux/SageTestLib/TestExecutive.cs
+++ b/Sage_Aux/SageTestLib/TestExecutive.cs
@@ -787,16 +787,20 @@ namespace Highpoint.Sage.SimCore {
 
             Console.WriteLine(m_result);
 
-            _Debug.Assert(m_result.Equals("5/16/2007 12:34:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:34:56 PM, is about to change.\r\n5/16/2007 12:35:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:35:56 PM, is about to change.\r\n5/16/2007 12:37:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:37:56 PM, is about to change.\r\n5/16/2007 12:40:56 PM : Event is firing.\r\n5/16/2007 12:40:56 PM : Event is firing.\r\n5/16/2007 12:40:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:40:56 PM, is about to change.\r\n5/16/2007 12:42:56 PM : Event is firing.\r\n5/16/2007 12:42:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:42:56 PM, is about to change.\r\n5/16/2007 12:44:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:44:56 PM, is about to change.\r\n5/16/2007 12:47:56 PM : Event is firing.\r\n5/16/2007 12:47:56 PM : Event is firing.\r\n5/16/2007 12:47:56 PM : Event is firing.\r\n5/16/2007 12:47:56 PM : Event is firing.\r\n\tClock, currently at 5/16/2007 12:47:56 PM, is about to change.\r\n5/16/2007 12:51:56 PM : Event is firing.\r\n"));
+            _Debug.Assert(m_result.Equals("16/05/2007 12:34:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:34:56 PM, is about to change.\r\n16/05/2007 12:35:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:35:56 PM, is about to change.\r\n16/05/2007 12:37:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:37:56 PM, is about to change.\r\n16/05/2007 12:40:56 PM : Event is firing.\r\n16/05/2007 12:40:56 PM : Event is firing.\r\n16/05/2007 12:40:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:40:56 PM, is about to change.\r\n16/05/2007 12:42:56 PM : Event is firing.\r\n16/05/2007 12:42:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:42:56 PM, is about to change.\r\n16/05/2007 12:44:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:44:56 PM, is about to change.\r\n16/05/2007 12:47:56 PM : Event is firing.\r\n16/05/2007 12:47:56 PM : Event is firing.\r\n16/05/2007 12:47:56 PM : Event is firing.\r\n16/05/2007 12:47:56 PM : Event is firing.\r\n\tClock, currently at 16/05/2007 12:47:56 PM, is about to change.\r\n16/05/2007 12:51:56 PM : Event is firing.\r\n"));
         }
 
         private string m_result = null;
         void exec1_ClockAboutToChange(IExecutive exec) {
-            m_result += ( "\tClock, currently at " + exec.Now + ", is about to change.\r\n" );
+            m_result += ( "\tClock, currently at " + getExecNow(exec) + ", is about to change.\r\n" );
         }
 
         void MyExecEventReceiver2(IExecutive exec, object userData) {
-            m_result += ( exec.Now + " : Event is firing.\r\n" );
+            m_result += (getExecNow(exec) + " : Event is firing.\r\n" );
+        }
+
+        private string getExecNow(IExecutive exec) {
+            return exec.Now.ToString("dd/MM/yyyy hh:mm:ss tt");
         }
 
         private int m_exec1_ExecutiveStarted_SingleShot_Count = 0;

--- a/Sage_Aux/SageTestLib/TestMaterialService.cs
+++ b/Sage_Aux/SageTestLib/TestMaterialService.cs
@@ -41,8 +41,8 @@ namespace Highpoint.Sage.Materials  {
             TestClient tc = new TestClient(model, source, sink, mcat["Ammonia"], 1000, mcat["Ammonia"], 750);
 
             model.Executive.RequestEvent(
-                new ExecEventReceiver(tc.Run), 
-                DateTime.Parse("2/16/2009 12:59:28 PM"), 0.0, new Hashtable(), ExecEventType.Detachable);
+                new ExecEventReceiver(tc.Run),
+                new DateTime(2009, 2, 16, 12, 59, 28), 0.0, new Hashtable(), ExecEventType.Detachable);
 
             model.Start();
         }

--- a/Sage_Aux/SageTestLib/TestMaterials.cs
+++ b/Sage_Aux/SageTestLib/TestMaterials.cs
@@ -729,7 +729,7 @@ namespace Highpoint.Sage.Materials.Chemistry  {
             MaterialTransferrer mxfr = new MaterialTransferrer(model, ref from, ref to, what, duration);
 
             // Create the start event for the transfer.
-            DateTime startAt = DateTime.Parse("2/23/2009 3:00:00 PM");
+            DateTime startAt = new DateTime(2009, 2, 23, 3, 0, 0);
             model.Executive.RequestEvent(delegate(IExecutive exec, object userData) { mxfr.Start(); }, startAt, 0.0, null);
             
             // Create a pause-til-start event.

--- a/Sage_Aux/SageTestLib/TestPriResources.cs
+++ b/Sage_Aux/SageTestLib/TestPriResources.cs
@@ -32,21 +32,21 @@ namespace Highpoint.Sage.Resources  {
 		[Highpoint.Sage.Utility.FieldDescription("First functional test of Resource Tester Infrastructural Class")]
 		public void TestBasicFuctionality(){
 			#region Expected Result
-			string expected = @"[User_0,Req,1/1/0001 12:05:00 AM,0]
-[User_1,Req,1/1/0001 12:05:00 AM,0]
-[User_2,Req,1/1/0001 12:05:00 AM,0]
-[User_3,Req,1/1/0001 12:05:00 AM,0]
-[User_4,Req,1/1/0001 12:05:00 AM,0]
-[User_0,Acq,1/1/0001 12:10:00 AM]
-[User_0,Rls,1/1/0001 12:15:00 AM]
-[User_1,Acq,1/1/0001 12:15:00 AM]
-[User_1,Rls,1/1/0001 12:20:00 AM]
-[User_2,Acq,1/1/0001 12:20:00 AM]
-[User_2,Rls,1/1/0001 12:25:00 AM]
-[User_3,Acq,1/1/0001 12:25:00 AM]
-[User_3,Rls,1/1/0001 12:30:00 AM]
-[User_4,Acq,1/1/0001 12:30:00 AM]
-[User_4,Rls,1/1/0001 12:35:00 AM]";
+			string expected = @"[User_0,Req,01/01/0001 12:05:00 AM,0]
+[User_1,Req,01/01/0001 12:05:00 AM,0]
+[User_2,Req,01/01/0001 12:05:00 AM,0]
+[User_3,Req,01/01/0001 12:05:00 AM,0]
+[User_4,Req,01/01/0001 12:05:00 AM,0]
+[User_0,Acq,01/01/0001 12:10:00 AM]
+[User_0,Rls,01/01/0001 12:15:00 AM]
+[User_1,Acq,01/01/0001 12:15:00 AM]
+[User_1,Rls,01/01/0001 12:20:00 AM]
+[User_2,Acq,01/01/0001 12:20:00 AM]
+[User_2,Rls,01/01/0001 12:25:00 AM]
+[User_3,Acq,01/01/0001 12:25:00 AM]
+[User_3,Rls,01/01/0001 12:30:00 AM]
+[User_4,Acq,01/01/0001 12:30:00 AM]
+[User_4,Rls,01/01/0001 12:35:00 AM]";
 			#endregion
 
 			m_resultString = "";
@@ -61,21 +61,21 @@ namespace Highpoint.Sage.Resources  {
 		[Highpoint.Sage.Utility.FieldDescription("First functional test of Resource Tester Infrastructural Class")]
 		public void TestPrioritizedResourceRequestHandling(){
 			#region Expected Result
-			string expected = @"[User_0,Req,1/1/0001 12:05:00 AM,0]
-[User_1,Req,1/1/0001 12:05:00 AM,1]
-[User_2,Req,1/1/0001 12:05:00 AM,2]
-[User_3,Req,1/1/0001 12:05:00 AM,3]
-[User_4,Req,1/1/0001 12:05:00 AM,4]
-[User_4,Acq,1/1/0001 12:10:00 AM]
-[User_4,Rls,1/1/0001 12:15:00 AM]
-[User_3,Acq,1/1/0001 12:15:00 AM]
-[User_3,Rls,1/1/0001 12:20:00 AM]
-[User_2,Acq,1/1/0001 12:20:00 AM]
-[User_2,Rls,1/1/0001 12:25:00 AM]
-[User_1,Acq,1/1/0001 12:25:00 AM]
-[User_1,Rls,1/1/0001 12:30:00 AM]
-[User_0,Acq,1/1/0001 12:30:00 AM]
-[User_0,Rls,1/1/0001 12:35:00 AM]
+			string expected = @"[User_0,Req,01/01/0001 12:05:00 AM,0]
+[User_1,Req,01/01/0001 12:05:00 AM,1]
+[User_2,Req,01/01/0001 12:05:00 AM,2]
+[User_3,Req,01/01/0001 12:05:00 AM,3]
+[User_4,Req,01/01/0001 12:05:00 AM,4]
+[User_4,Acq,01/01/0001 12:10:00 AM]
+[User_4,Rls,01/01/0001 12:15:00 AM]
+[User_3,Acq,01/01/0001 12:15:00 AM]
+[User_3,Rls,01/01/0001 12:20:00 AM]
+[User_2,Acq,01/01/0001 12:20:00 AM]
+[User_2,Rls,01/01/0001 12:25:00 AM]
+[User_1,Acq,01/01/0001 12:25:00 AM]
+[User_1,Rls,01/01/0001 12:30:00 AM]
+[User_0,Acq,01/01/0001 12:30:00 AM]
+[User_0,Rls,01/01/0001 12:35:00 AM]
 ";
 			#endregion
 
@@ -97,21 +97,21 @@ namespace Highpoint.Sage.Resources  {
 		[Highpoint.Sage.Utility.FieldDescription("First functional test of Resource Tester Infrastructural Class")]
 		public void TestPrioritizedResourceRequestWRemoval_1(){
 			#region Expected Result
-			string expected = @"[User_0,Req,1/1/0001 12:05:00 AM,0]
-[User_1,Req,1/1/0001 12:05:00 AM,1]
-[User_2,Req,1/1/0001 12:05:00 AM,2]
-[User_3,Req,1/1/0001 12:05:00 AM,3]
-[User_4,Req,1/1/0001 12:05:00 AM,4]
-[User_4,Acq,1/1/0001 12:10:00 AM]
-[User_4,Rls,1/1/0001 12:15:00 AM]
-[User_2,Acq,1/1/0001 12:15:00 AM]
-[User_2,Rls,1/1/0001 12:20:00 AM]
-[User_3,Acq,1/1/0001 12:20:00 AM]
-[User_3,Rls,1/1/0001 12:25:00 AM]
-[User_1,Acq,1/1/0001 12:25:00 AM]
-[User_1,Rls,1/1/0001 12:30:00 AM]
-[User_0,Acq,1/1/0001 12:30:00 AM]
-[User_0,Rls,1/1/0001 12:35:00 AM]
+			string expected = @"[User_0,Req,01/01/0001 12:05:00 AM,0]
+[User_1,Req,01/01/0001 12:05:00 AM,1]
+[User_2,Req,01/01/0001 12:05:00 AM,2]
+[User_3,Req,01/01/0001 12:05:00 AM,3]
+[User_4,Req,01/01/0001 12:05:00 AM,4]
+[User_4,Acq,01/01/0001 12:10:00 AM]
+[User_4,Rls,01/01/0001 12:15:00 AM]
+[User_2,Acq,01/01/0001 12:15:00 AM]
+[User_2,Rls,01/01/0001 12:20:00 AM]
+[User_3,Acq,01/01/0001 12:20:00 AM]
+[User_3,Rls,01/01/0001 12:25:00 AM]
+[User_1,Acq,01/01/0001 12:25:00 AM]
+[User_1,Rls,01/01/0001 12:30:00 AM]
+[User_0,Acq,01/01/0001 12:30:00 AM]
+[User_0,Rls,01/01/0001 12:35:00 AM]
 ";
 			#endregion
 			m_prt = new PriRscReqTester(5);
@@ -132,21 +132,21 @@ namespace Highpoint.Sage.Resources  {
 		[Highpoint.Sage.Utility.FieldDescription("First functional test of Resource Tester Infrastructural Class")]
 		public void TestPrioritizedResourceRequestWRemoval_2(){
 			#region Expected Result
-			string expected = @"[User_0,Req,1/1/0001 12:05:00 AM,0]
-[User_1,Req,1/1/0001 12:05:00 AM,0]
-[User_2,Req,1/1/0001 12:05:00 AM,0]
-[User_3,Req,1/1/0001 12:05:00 AM,0]
-[User_4,Req,1/1/0001 12:05:00 AM,0]
-[User_0,Acq,1/1/0001 12:10:00 AM]
-[User_0,Rls,1/1/0001 12:15:00 AM]
-[User_2,Acq,1/1/0001 12:15:00 AM]
-[User_2,Rls,1/1/0001 12:20:00 AM]
-[User_1,Acq,1/1/0001 12:20:00 AM]
-[User_1,Rls,1/1/0001 12:25:00 AM]
-[User_3,Acq,1/1/0001 12:25:00 AM]
-[User_3,Rls,1/1/0001 12:30:00 AM]
-[User_4,Acq,1/1/0001 12:30:00 AM]
-[User_4,Rls,1/1/0001 12:35:00 AM]
+			string expected = @"[User_0,Req,01/01/0001 12:05:00 AM,0]
+[User_1,Req,01/01/0001 12:05:00 AM,0]
+[User_2,Req,01/01/0001 12:05:00 AM,0]
+[User_3,Req,01/01/0001 12:05:00 AM,0]
+[User_4,Req,01/01/0001 12:05:00 AM,0]
+[User_0,Acq,01/01/0001 12:10:00 AM]
+[User_0,Rls,01/01/0001 12:15:00 AM]
+[User_2,Acq,01/01/0001 12:15:00 AM]
+[User_2,Rls,01/01/0001 12:20:00 AM]
+[User_1,Acq,01/01/0001 12:20:00 AM]
+[User_1,Rls,01/01/0001 12:25:00 AM]
+[User_3,Acq,01/01/0001 12:25:00 AM]
+[User_3,Rls,01/01/0001 12:30:00 AM]
+[User_4,Acq,01/01/0001 12:30:00 AM]
+[User_4,Rls,01/01/0001 12:35:00 AM]
 ";
 			#endregion
 			m_prt = new PriRscReqTester(5);
@@ -213,12 +213,17 @@ namespace Highpoint.Sage.Resources  {
 			}
 
 			private void ReleaseResource(IExecutive exec, object userData) {
-				Console.WriteLine("Releasing the resource at " + exec.Now );
+				Console.WriteLine("Releasing the resource at " + getExecNow(exec));
 				m_rscReq.Release();
 			}
-		}
 
-		class ResourceUser : IModelObject {
+		    private string getExecNow(IExecutive exec)
+		    {
+		        return exec.Now.ToString("dd/MM/yyyy HH:mm:ss tt");
+		    }
+        }
+
+        class ResourceUser : IModelObject {
 			private IResourceRequest m_irr;
 			public ResourceUser(IModel model, string name, Guid guid, SelfManagingResource smr){
                 InitializeIdentity(model, name, null, guid);
@@ -240,21 +245,26 @@ namespace Highpoint.Sage.Resources  {
 			}
 
 			private void DoResourceAction(IExecutive exec, object obj){
-				m_resultString += ("[" + this.Name + ",Req," + exec.Now + "," + m_irr.Priority + "]\r\n");
-				Console.WriteLine("At time " + exec.Now + ", " + m_name + " trying to acquire with a priority of " + m_irr.Priority );
+				m_resultString += ("[" + this.Name + ",Req," + getExecNow(exec) + "," + m_irr.Priority + "]\r\n");
+				Console.WriteLine("At time " + getExecNow(exec) + ", " + m_name + " trying to acquire with a priority of " + m_irr.Priority );
 				m_irr.Acquire(m_irr.DefaultResourceManager,true);
-				m_resultString += ("[" + this.Name + ",Acq," + exec.Now + "]\r\n");
-				Console.WriteLine("At time " + exec.Now + ", " + m_name + " acquired...");
+				m_resultString += ("[" + this.Name + ",Acq," + getExecNow(exec) + "]\r\n");
+				Console.WriteLine("At time " + getExecNow(exec) + ", " + m_name + " acquired...");
 				exec.CurrentEventController.SuspendUntil(exec.Now+TimeSpan.FromMinutes(5.0));
-				Console.WriteLine("At time " + exec.Now + ", " + m_name + " releasing...");
-				m_resultString += ("[" + this.Name + ",Rls," + exec.Now  + "]\r\n");
+				Console.WriteLine("At time " + getExecNow(exec) + ", " + m_name + " releasing...");
+				m_resultString += ("[" + this.Name + ",Rls," + getExecNow(exec) + "]\r\n");
 				m_irr.Release();
 				Console.WriteLine("...and release is done.");
 
 			}
 
-			#region Implementation of IModelObject
-			private string m_name = null;
+            private string getExecNow(IExecutive exec)
+            {
+                return exec.Now.ToString("dd/MM/yyyy hh:mm:ss tt");
+            }
+
+            #region Implementation of IModelObject
+            private string m_name = null;
 			public string Name { get { return m_name; } }
 			private string m_description = null;
 			/// <summary>


### PR DESCRIPTION
Several tests were failing on my machine as dates within messages were in the MM/dd/yyyy format, whilst my machine was using the dd/MM/yyyy format.