### PR TITLE
Add assertions to TestServerBasics

### DIFF
--- a/Sage_Aux/SageTestLib/TestServers.cs
+++ b/Sage_Aux/SageTestLib/TestServers.cs
@@ -78,9 +78,14 @@ namespace Highpoint.Sage.ItemBased.Blocks {
 			outPatientTreat.ServiceBeginning+=new ServiceEvent(Server_ServiceBeginning);
 			outPatientTreat.ServiceCompleted+=new ServiceEvent(Server_ServiceCompleted);
 
-			m_model.Start();
+                        m_model.Start();
 
-			Console.WriteLine("NoAdmit = " + m_noAdmitCount + ", and admitted = " + m_admitCount);
+                        Console.WriteLine("NoAdmit = " + m_noAdmitCount + ", and admitted = " + m_admitCount);
+
+                        Assert.AreEqual(500, m_admitCount + m_noAdmitCount,
+                            "All generated patients should have been processed.");
+                        Assert.IsTrue(m_admitCount > 0 && m_noAdmitCount > 0,
+                            "Both admitted and non-admitted counts should be greater than zero.");
 
 		}
 


### PR DESCRIPTION
## Summary
- update `TestServerBasics` to assert total patient count equals 500 and that both counts are greater than zero

## Testing
- `dotnet build Sage4-Everything.sln -c Release` *(fails: reference assemblies for .NETFramework v4.8 not found)*
- `xbuild Sage_Aux/SageTestLib/SageTestLib.csproj /target:Build` *(fails: Invalid type 'System.Globalization.CultureInfo' used in static method invocation)*

------
https://chatgpt.com/codex/tasks/task_e_6873f3c8a518832faf2702ef4df14afd