### PR TITLE
Fix typo in ValidationService comment

### DIFF
--- a/Sage/Graphs/ValidationService.cs
+++ b/Sage/Graphs/ValidationService.cs
@@ -170,7 +170,7 @@ namespace Highpoint.Sage.Graphs.Validity {
 		public void Refresh(bool force){
 			if ( force) m_dirty = true;
 
-			m_suspensions=0; // TODO: Check if this scould capture & restore the m_suspensions value.
+                        m_suspensions=0; // TODO: Check if this should capture & restore the m_suspensions value.
 
 			Refresh();
 		}


### PR DESCRIPTION
## Summary
- fix typo in `Refresh` comment

## Testing
- `dotnet build Sage/Sage4.csproj` *(fails: command not found)*
- `msbuild Sage/Sage4.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740473fa8c832f9f7d533f3da1e764